### PR TITLE
add default cache name

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -17,7 +17,7 @@ const schema = {
 const config = {
   port: process.env.PORT,
   env: process.env.NODE_ENV,
-  cacheName: process.env.MINE_SUPPORT_CACHE_NAME,
+  cacheName: process.env.MINE_SUPPORT_CACHE_NAME || 'minesupportcache',
   redisHost: process.env.REDIS_HOSTNAME,
   redisPort: process.env.REDIS_PORT,
   cookiePassword: process.env.COOKIE_PASSWORD,


### PR DESCRIPTION
lack of default was causing the redis cache to be the default for all requests, rather than the memory cache