### PR TITLE
allow unsecure cookie in production

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -17,7 +17,7 @@ const schema = {
 const config = {
   port: process.env.PORT,
   env: process.env.NODE_ENV,
-  cacheName: process.env.MINE_SUPPORT_CACHE_NAME || 'minesupportcache',
+  cacheName: process.env.MINE_SUPPORT_CACHE_NAME,
   redisHost: process.env.REDIS_HOSTNAME,
   redisPort: process.env.REDIS_PORT,
   cookiePassword: process.env.COOKIE_PASSWORD,

--- a/server/plugins/session-cache.js
+++ b/server/plugins/session-cache.js
@@ -10,7 +10,9 @@ module.exports = {
     },
     cookieOptions: {
       password: config.cookiePassword,
-      isSecure: config.env !== 'development'
+      // production is currently not https, so a new cookie is created for every request, including css
+      // isSecure: config.env !== 'development'
+      isSecure: false
     }
   }
 }


### PR DESCRIPTION
 allow unsecured cookie as https is currently not used an sample app deployment